### PR TITLE
Bump MLflow from 3.2.0 to 3.3.1

### DIFF
--- a/docs/hub/README.md
+++ b/docs/hub/README.md
@@ -8,6 +8,7 @@ Welcome to our MLflow Docker repository! You can find all our Docker files in ou
 
 # Simple Tags
 
+- [3.3.1](https://github.com/burakince/mlflow/blob/3.3.1/Dockerfile)
 - [3.2.0](https://github.com/burakince/mlflow/blob/3.2.0/Dockerfile)
 - [3.1.4](https://github.com/burakince/mlflow/blob/3.1.4/Dockerfile)
 - [3.1.3](https://github.com/burakince/mlflow/blob/3.1.3/Dockerfile)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2014,14 +2014,14 @@ dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setup
 
 [[package]]
 name = "mlflow"
-version = "3.2.0"
+version = "3.3.1"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mlflow-3.2.0-py3-none-any.whl", hash = "sha256:db97b925cc8afba15caf3749dcb4a95be83f9608e974f23253fbbc1d675247ea"},
-    {file = "mlflow-3.2.0.tar.gz", hash = "sha256:e96bd42238ea8b477691c8a8f6e8bdbf9247415ad7892e6e885994c6940bcf74"},
+    {file = "mlflow-3.3.1-py3-none-any.whl", hash = "sha256:a78a032cf5392a608bba1a6ee59c9bbd6b1d29b2ea2598e4e2ce7a20ccaf1eea"},
+    {file = "mlflow-3.3.1.tar.gz", hash = "sha256:05159afb08e898f11b0f71f29d5b27e5e5248f0099c449567dcb8a52e9b07463"},
 ]
 
 [package.dependencies]
@@ -2029,6 +2029,7 @@ alembic = "<1.10.0 || >1.10.0,<2"
 azureml-core = {version = ">=1.2.0", optional = true, markers = "extra == \"extras\""}
 boto3 = {version = "*", optional = true, markers = "extra == \"extras\""}
 botocore = {version = "*", optional = true, markers = "extra == \"extras\""}
+cryptography = ">=43.0.0,<46"
 docker = ">=4.0.0,<8"
 Flask = "<4"
 Flask-WTF = {version = "<2", optional = true, markers = "extra == \"auth\""}
@@ -2037,8 +2038,8 @@ graphene = "<4"
 gunicorn = {version = "<24", markers = "platform_system != \"Windows\""}
 kubernetes = {version = "*", optional = true, markers = "extra == \"extras\""}
 matplotlib = "<4"
-mlflow-skinny = "3.2.0"
-mlflow-tracing = "3.2.0"
+mlflow-skinny = "3.3.1"
+mlflow-tracing = "3.3.1"
 numpy = "<3"
 pandas = "<3"
 prometheus-flask-exporter = {version = "*", optional = true, markers = "extra == \"extras\""}
@@ -2065,18 +2066,17 @@ jfrog = ["mlflow-jfrog-plugin"]
 langchain = ["langchain (>=0.1.0,<=0.3.27)"]
 mlserver = ["mlserver (>=1.2.0,!=1.3.1,<2.0.0)", "mlserver-mlflow (>=1.2.0,!=1.3.1,<2.0.0)"]
 sqlserver = ["mlflow-dbstore"]
-xethub = ["mlflow-xethub"]
 
 [[package]]
 name = "mlflow-skinny"
-version = "3.2.0"
+version = "3.3.1"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mlflow_skinny-3.2.0-py3-none-any.whl", hash = "sha256:ec33a6fc164973e3b4d208e4ab8bec118ea93ff890ffbd08817b66468235ed71"},
-    {file = "mlflow_skinny-3.2.0.tar.gz", hash = "sha256:b359ec082a0a966e4e8e80f03d850da7fa677ebe57e67b1c0877029e5eeee443"},
+    {file = "mlflow_skinny-3.3.1-py3-none-any.whl", hash = "sha256:0955568f6a97db9456314439fcf8392c9f9f24c8085948f45d2db933a7520eed"},
+    {file = "mlflow_skinny-3.3.1.tar.gz", hash = "sha256:1a95be40086a3d0f109ae918b214df3230199793afe10a42ddc7dc2176f8656c"},
 ]
 
 [package.dependencies]
@@ -2109,18 +2109,17 @@ jfrog = ["mlflow-jfrog-plugin"]
 langchain = ["langchain (>=0.1.0,<=0.3.27)"]
 mlserver = ["mlserver (>=1.2.0,!=1.3.1,<2.0.0)", "mlserver-mlflow (>=1.2.0,!=1.3.1,<2.0.0)"]
 sqlserver = ["mlflow-dbstore"]
-xethub = ["mlflow-xethub"]
 
 [[package]]
 name = "mlflow-tracing"
-version = "3.2.0"
+version = "3.3.1"
 description = "MLflow Tracing SDK is an open-source, lightweight Python package that only includes the minimum set of dependencies and functionality to instrument your code/models/agents with MLflow Tracing."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mlflow_tracing-3.2.0-py3-none-any.whl", hash = "sha256:4180d48b6b68a70b3e37987def3b0689d3f4ba722f5d2b98344c3717d2289b99"},
-    {file = "mlflow_tracing-3.2.0.tar.gz", hash = "sha256:6f3dd940752ca28871b09880e9426d1293460822faa8706b33af1d50c29a0355"},
+    {file = "mlflow_tracing-3.3.1-py3-none-any.whl", hash = "sha256:ab92e6287fdaac2940528b520f1728a300d02b5858052f0c5831df2b1bb4fbbc"},
+    {file = "mlflow_tracing-3.3.1.tar.gz", hash = "sha256:ba2973300836b8d656ec516f64145130bbe07332e43429765507234db8a8f632"},
 ]
 
 [package.dependencies]
@@ -4187,4 +4186,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "4fd5ba3371aa5cbd4f7ce9e1c55e0896c87dc6d6f4d7d93307ddb9cd11306273"
+content-hash = "ac91d639cd47db32a725bdd41f4bc12f45071a8ecf2027e305d9e3ea96407531"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Burak Ince", email = "burak.ince@linux.org.tr" },
 ]
 dependencies = [
-  "mlflow[auth,extras,pipelines] (>=3.2.0,<4.0.0)",
+  "mlflow[auth,extras,pipelines] (>=3.3.1,<4.0.0)",
   "pymysql (>=1.1.1,<2.0.0)",
   "psycopg2-binary (>=2.9.10,<3.0.0)",
   "boto3 (>=1.40.11,<2.0.0)",


### PR DESCRIPTION
Update the MLflow version in project files and add a new tag link for version 3.3.1 in the README.